### PR TITLE
build: make `just check` run formatting in check mode

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -9,10 +9,13 @@ summary file='fixtures/smoke/minimal.pcap':
 fmt:
     cargo fmt --all
 
+fmt-check:
+    cargo fmt --all -- --check
+
 clippy:
     cargo clippy --workspace --all-targets -- -D warnings
 
 test:
     cargo test --workspace
 
-check: fmt clippy test
+check: fmt-check clippy test

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ just test
 Cargo equivalents:
 
 ```bash
-cargo fmt --all
+cargo fmt --all -- --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
 ```

--- a/crates/fireshark-cli/tests/justfile_docs.rs
+++ b/crates/fireshark-cli/tests/justfile_docs.rs
@@ -16,9 +16,10 @@ fn repo_has_expected_justfile_recipes() {
 
     assert!(justfile.contains("summary file='fixtures/smoke/minimal.pcap':"));
     assert!(justfile.contains("fmt:"));
+    assert!(justfile.contains("fmt-check:"));
     assert!(justfile.contains("clippy:"));
     assert!(justfile.contains("test:"));
-    assert!(justfile.contains("check: fmt clippy test"));
+    assert!(justfile.contains("check: fmt-check clippy test"));
 }
 
 #[test]
@@ -28,5 +29,6 @@ fn readme_documents_just_first_workflow() {
     assert!(readme.contains("just summary"));
     assert!(readme.contains("just check"));
     assert!(readme.contains("cargo run -p fireshark-cli -- summary"));
+    assert!(readme.contains("cargo fmt --all -- --check"));
     assert!(readme.contains("cargo test --workspace"));
 }


### PR DESCRIPTION
### Motivation

- Prevent the `check` workflow from mutating source files during verification by running formatting in check mode instead of performing format edits.
- Keep documentation and tests in sync with the non-mutating verification behavior so CI and local checks reflect the same commands.

### Description

- Added a `fmt-check` recipe to the `Justfile` that runs `cargo fmt --all -- --check` and changed the `check` recipe to depend on `fmt-check` instead of `fmt`.
- Updated `README.md` to document the format check command in the "Cargo equivalents" section using `cargo fmt --all -- --check`.
- Updated the `crates/fireshark-cli/tests/justfile_docs.rs` test to expect the new `fmt-check` recipe and the updated `check` dependency chain, and to assert the README documents the format-check command.

### Testing

- Ran `cargo fmt --all --check`, which completed successfully in this environment. 
- Attempted `cargo test -p fireshark-cli --test justfile_docs --offline`, which could not complete due to the environment being offline and failing to resolve dependencies from crates.io (missing `pcap-file`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b78b7430d0832682d98a08c8ddee9b)