### PR TITLE
fix: reject short capture files as unsupported format

### DIFF
--- a/crates/fireshark-file/src/reader.rs
+++ b/crates/fireshark-file/src/reader.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::io::{Read, Seek, SeekFrom};
+use std::io::{ErrorKind, Read, Seek, SeekFrom};
 use std::path::Path;
 
 use fireshark_core::Frame;
@@ -24,11 +24,7 @@ enum ReaderKind {
 impl CaptureReader {
     pub fn open(path: impl AsRef<Path>) -> Result<Self, CaptureError> {
         let mut file = File::open(path)?;
-        let mut magic = [0_u8; 4];
-        let bytes_read = file.read(&mut magic)?;
-        if bytes_read < magic.len() {
-            return Err(CaptureError::UnsupportedFormat);
-        }
+        let magic = read_magic_prefix(&mut file)?;
         file.seek(SeekFrom::Start(0))?;
 
         let inner = if magic == PCAPNG_MAGIC {
@@ -48,6 +44,17 @@ impl CaptureReader {
         };
 
         Ok(Self { inner })
+    }
+}
+
+fn read_magic_prefix<R: Read>(reader: &mut R) -> Result<[u8; 4], CaptureError> {
+    let mut magic = [0_u8; 4];
+    match reader.read_exact(&mut magic) {
+        Ok(()) => Ok(magic),
+        Err(error) if error.kind() == ErrorKind::UnexpectedEof => {
+            Err(CaptureError::UnsupportedFormat)
+        }
+        Err(error) => Err(CaptureError::Io(error)),
     }
 }
 
@@ -138,4 +145,51 @@ fn validate_pcapng_linktypes(reader: &mut PcapNgReader<File>) -> Result<(), Capt
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{self, Cursor, Read};
+
+    use super::{PCAPNG_MAGIC, read_magic_prefix};
+    use crate::CaptureError;
+
+    struct ShortReadCursor {
+        inner: Cursor<Vec<u8>>,
+        max_chunk_len: usize,
+    }
+
+    impl ShortReadCursor {
+        fn new(bytes: Vec<u8>, max_chunk_len: usize) -> Self {
+            Self {
+                inner: Cursor::new(bytes),
+                max_chunk_len,
+            }
+        }
+    }
+
+    impl Read for ShortReadCursor {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            let max_chunk_len = self.max_chunk_len.min(buf.len());
+            self.inner.read(&mut buf[..max_chunk_len])
+        }
+    }
+
+    #[test]
+    fn reads_magic_prefix_across_short_non_eof_reads() {
+        let mut reader = ShortReadCursor::new(PCAPNG_MAGIC.to_vec(), 2);
+
+        let magic = read_magic_prefix(&mut reader).unwrap();
+
+        assert_eq!(magic, PCAPNG_MAGIC);
+    }
+
+    #[test]
+    fn rejects_true_eof_before_magic_prefix_is_complete() {
+        let mut reader = ShortReadCursor::new(vec![0x0a, 0x0d, 0x0d], 2);
+
+        let error = read_magic_prefix(&mut reader).unwrap_err();
+
+        assert!(matches!(error, CaptureError::UnsupportedFormat));
+    }
 }

--- a/crates/fireshark-file/src/reader.rs
+++ b/crates/fireshark-file/src/reader.rs
@@ -25,7 +25,10 @@ impl CaptureReader {
     pub fn open(path: impl AsRef<Path>) -> Result<Self, CaptureError> {
         let mut file = File::open(path)?;
         let mut magic = [0_u8; 4];
-        file.read_exact(&mut magic)?;
+        let bytes_read = file.read(&mut magic)?;
+        if bytes_read < magic.len() {
+            return Err(CaptureError::UnsupportedFormat);
+        }
         file.seek(SeekFrom::Start(0))?;
 
         let inner = if magic == PCAPNG_MAGIC {

--- a/crates/fireshark-file/tests/reject_short_capture.rs
+++ b/crates/fireshark-file/tests/reject_short_capture.rs
@@ -1,0 +1,27 @@
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use fireshark_file::{CaptureError, CaptureReader};
+
+#[test]
+fn rejects_capture_shorter_than_magic_prefix() {
+    let path = temp_capture_path();
+    fs::write(&path, [0x0a, 0x0d, 0x0d]).unwrap();
+
+    let result = CaptureReader::open(&path);
+
+    fs::remove_file(&path).unwrap();
+    assert!(matches!(result, Err(CaptureError::UnsupportedFormat)));
+}
+
+fn temp_capture_path() -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "fireshark-short-capture-{unique}-{}.pcap",
+        std::process::id(),
+    ))
+}


### PR DESCRIPTION
### Motivation
- Treat files shorter than the 4-byte capture format probe as an unsupported format instead of surfacing an `Io(UnexpectedEof)` to callers. 
- Add a regression to ensure short/invalid captures are classified consistently.

### Description
- Replace `file.read_exact(&mut magic)?` with `file.read(&mut magic)?` and return `Err(CaptureError::UnsupportedFormat)` when fewer than 4 bytes are read in `CaptureReader::open` (see `crates/fireshark-file/src/reader.rs`).
- Add `crates/fireshark-file/tests/reject_short_capture.rs`, a test that writes a 3-byte temporary file and asserts `CaptureReader::open` returns `CaptureError::UnsupportedFormat`.

### Testing
- `cargo fmt --all -- --check` ran and succeeded.
- `cargo test -p fireshark-file --tests --offline` was attempted but failed due to offline crate resolution (crates.io index unavailable), so the package tests could not be fully executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b78c9e54e483268e52e91878fe19ac)